### PR TITLE
Update to STARE 1.2.6 for expandIntervals bugfix (108).

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "stare" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/SpatioTemporal/STARE/archive/{{ version }}.tar.gz
-  sha256: 502f9ca18b1185258863d06f6deacc7ac0354b7913dc1626f3a48a78c3b5b42d
+  sha256: c64a1b9f4572c9c54f11f1171579c8f4c0f534c64cd49cb834e972da378a40af
 build:
   number: 0
   skip: true  # [win]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is just a simple update from 1.2.5 to 1.2.6.